### PR TITLE
[Linter] Invalid Linter received

### DIFF
--- a/lib/linter-json-lint-provider.js
+++ b/lib/linter-json-lint-provider.js
@@ -11,8 +11,6 @@ export default {
 
   scope: 'file',
 
-  lintOnFly: true,
-
   lintsOnChange: true,
 
   lint (textEditor) {

--- a/lib/linter-json-lint-provider.js
+++ b/lib/linter-json-lint-provider.js
@@ -13,6 +13,8 @@ export default {
 
   lintOnFly: true,
 
+  lintsOnChange: true,
+
   lint (textEditor) {
     return new Promise((resolve, reject) => {
       var lint = JSONLint(textEditor.getText(), {


### PR DESCRIPTION
There was a warning on Atom startup:
```
[Linter] Invalid Linter received
These issues were encountered while registering a Linter named 'json-lint'
  • Linter.lintsOnChange must be a boolean
```

Replace the old `lintOnFly` property with `lintsOnChange` to properly register as a Linter API v2 provider.